### PR TITLE
Don't commit the JdbcCallEvent multiple times

### DIFF
--- a/src/main/java/com/github/marschall/jfr/jdbc/JdbcCallEvent.java
+++ b/src/main/java/com/github/marschall/jfr/jdbc/JdbcCallEvent.java
@@ -25,4 +25,11 @@ class JdbcCallEvent extends Event {
     this.query = query;
   }
 
+  void close() {
+    if (!closed) {
+      closed = true;
+      end();
+      commit();
+    }
+  }
 }

--- a/src/main/java/com/github/marschall/jfr/jdbc/JfrPreparedStatement.java
+++ b/src/main/java/com/github/marschall/jfr/jdbc/JfrPreparedStatement.java
@@ -53,9 +53,7 @@ class JfrPreparedStatement extends JfrStatement implements PreparedStatement {
   @Override
   public void close() throws SQLException {
     if (!this.closed && !this.callEvent.closed) {
-      this.callEvent.end();
-      this.callEvent.commit();
-      this.callEvent.closed = true;
+      this.callEvent.close();
       this.closed = true;
     }
     this.delegate.close();
@@ -228,9 +226,7 @@ class JfrPreparedStatement extends JfrStatement implements PreparedStatement {
   @Override
   public void clearParameters() throws SQLException {
     if (!this.closed && !this.callEvent.closed) {
-      this.callEvent.end();
-      this.callEvent.commit();
-      this.callEvent.closed = true;
+      this.callEvent.close();
       
       this.callEvent = new JdbcCallEvent(this.callEvent.query);
     }

--- a/src/main/java/com/github/marschall/jfr/jdbc/JfrResultSet.java
+++ b/src/main/java/com/github/marschall/jfr/jdbc/JfrResultSet.java
@@ -55,9 +55,7 @@ class JfrResultSet implements ResultSet {
   public void close() throws SQLException {
     if (!this.closed) {
       this.callEvent.rowCount = this.rowCount;
-      this.callEvent.end();
-      this.callEvent.commit();
-      this.callEvent.closed = true;
+      this.callEvent.close();
       this.callEvent = null;
       this.closed = true;
     }


### PR DESCRIPTION
The previous method of closing the JdbcCallEvent was not consistent. The same event was committed multiple times, resulting in hard to understand JFRs.